### PR TITLE
Support monitoring urls and files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Below is an example usage.
 .. code-block:: console
 
     $ dump1090exporter \
-      --url=http://192.168.1.201:8080 \
+      --resource-path=http://192.168.1.201:8080 \
       --port=9105 \
       --latitude=-34.9285 \
       --longitude=138.6007 \
@@ -67,15 +67,28 @@ origin (lat, lon). In this case it is for Adelaide, Australia. In most
 cases the dump1090 tool is not configured with the receivers position.
 By providing the exporter with the receiver location it can calculate
 ranges to aircraft. If the receiver position is already set within the
-dump1090 tool (and accessible from the *data/receivers.json* resource)
-then the exporter will use that data as the origin.
+dump1090 tool (and accessible from the *{resource-path}data/receivers.json*
+resource) then the exporter will use that data as the origin.
 
-The exporter fetches aircraft data (from *data/aircraft.json*) every 10
-seconds. This can be modified by specifying a new value with the
+The dump1090exporter can also monitor dump1090 status via the file system if
+you run it on the same machine. In this scenario you would pass a file system
+path to the ``--resource-path`` command line argument. For example:
+
+.. code-block:: console
+
+    $ dump1090exporter \
+      --resource-path=/path/to/dump1090-base-dir \
+      --port=9105 \
+      --latitude=-34.9285 \
+      --longitude=138.6007 \
+      --debug
+
+The exporter fetches aircraft data (from *{resource-path}/data/aircraft.json*)
+every 10 seconds. This can be modified by specifying a new value with the
 *--aircraft-interval* argument.
 
-The exporter fetches statistics data (from *data/stats.json*) every 60
-seconds, as the primary metrics being exported are extracted from the
+The exporter fetches statistics data (from *{resource-path}data/stats.json*)
+every 60 seconds, as the primary metrics being exported are extracted from the
 *last1min* time period. This too can be modified by specifying a new
 value with the *--stats-interval* argument.
 
@@ -168,7 +181,7 @@ command argument is *--help* which will display help information.
 .. code-block:: console
 
     $ docker run -it --rm clawsicus/dump1090exporter
-    usage: dump1090exporter [-h] [--url <dump1090 url>]
+    usage: dump1090exporter [-h] [--resource-path <dump1090 url>]
     ...
 
 To run the dump1090 exporter container in your environment simply pass your
@@ -179,7 +192,7 @@ own custom command line arguments to it:
     $ docker run -p 9105:9105 \
       --detach \
       clawsicus/dump1090exporter \
-      --url=http://192.168.1.201:8080 \
+      --resource-path=http://192.168.1.201:8080 \
       --latitude=-34.9285 \
       --longitude=138.6007
 
@@ -294,7 +307,7 @@ The following steps are used to make a new software release:
   .. code-block:: console
 
       $ docker run -it --rm clawsicus/dump1090exporter
-      usage: dump1090exporter [-h] [--url <dump1090 url>]
+      usage: dump1090exporter [-h] [--resource-path <dump1090 url>]
       ...
 
 - Test it by connecting it to a dump1090 service.

--- a/demo/README.md
+++ b/demo/README.md
@@ -15,7 +15,7 @@ instance:
 
 ``` yaml
 command: [
-  "--url=http://192.168.1.201:8080",
+  "--resource-path=http://192.168.1.201:8080",
   "--latitude=-34.9285",
   "--longitude=138.6007"]
 ```

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     restart: always
     stop_signal: SIGINT
     command: [
-      "--url=http://192.168.1.201:8080",
+      "--resource-path=http://192.168.1.201:8080",
       "--latitude=-34.9285",
       "--longitude=138.6007"]
 

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,6 @@ def parse_requirements(filename):
     return lines
 
 
-requirements = parse_requirements("requirements.txt")
-
-
 if __name__ == "__main__":
 
     setup(
@@ -50,7 +47,11 @@ if __name__ == "__main__":
         url="https://github.com/claws/dump1090-exporter",
         package_dir={"": "src"},
         packages=find_packages("src"),
-        install_requires=requirements,
+        install_requires=parse_requirements("requirements.txt"),
+        extras_require={
+            "develop": parse_requirements("requirements.dev.txt"),
+            "uvloop": ["uvloop"],
+        },
         classifiers=[
             "Development Status :: 5 - Production/Stable",
             "Intended Audience :: Developers",

--- a/src/dump1090exporter/__init__.py
+++ b/src/dump1090exporter/__init__.py
@@ -1,3 +1,3 @@
 from .exporter import Dump1090Exporter
 
-__version__ = "18.7.1"
+__version__ = "20.0.0"

--- a/src/dump1090exporter/__main__.py
+++ b/src/dump1090exporter/__main__.py
@@ -1,8 +1,15 @@
 import argparse
 import asyncio
 import logging
-
 from .exporter import Dump1090Exporter
+
+# try to import uvloop - optional
+try:
+    import uvloop
+
+    uvloop.install()
+except ImportError:
+    pass
 
 
 def main():
@@ -12,11 +19,11 @@ def main():
         prog="dump1090exporter", description="dump1090 Prometheus Exporter"
     )
     ARGS.add_argument(
-        "--url",
-        metavar="<dump1090 url>",
+        "--resource-path",
+        metavar="<dump1090 url or dirpath>",
         type=str,
         default="http://localhost:8080",
-        help="Url of the dump1090 service to be monitored",
+        help="dump1090 URL or directory path of the dump1090 service",
     )
     ARGS.add_argument(
         "--host",
@@ -77,7 +84,7 @@ def main():
 
     loop = asyncio.get_event_loop()
     mon = Dump1090Exporter(
-        url=args.url,
+        resource_path=args.resource_path,
         host=args.host,
         port=args.port,
         aircraft_interval=args.aircraft_interval,


### PR DESCRIPTION
This merge request updates the dump1090exporter Python package to support directly monitoring the various dump1090 status files (requested in #19) in the scenario where a user decides to deploy it onto the same device that is running dump1090.

- updated code to support URLs or a data directory
- bumped version number
- updated docs
- updated docker-compose environment