### PR TITLE
Quick fix for issue related to aioprometheus API change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 # Define the specific version of Python you want Make to use when creating
 # a virtual environment.
-PYTHON := python3.8
+PYTHON := python3.9
 
 # Do not remove this block. It is used by the 'help' rule when
 # constructing the help output.

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ dump1090 Exporter
 .. note::
 
     This exporter currently works with the mutability fork of dump1090, using
-    the ``/path/to/dump1090-base-dir/data/aicraft.json`` and
+    the ``/path/to/dump1090-base-dir/data/aircraft.json`` and
     ``/path/to/dump1090-base-dir/data/receivers.json`` routes as well as
     with the dump1090-fa fork using the ``/run/dump1090-fa/`` route.
     Those are used by the exporter to fetch metrics.
@@ -331,4 +331,4 @@ The following steps are used to make a new software release:
 
   .. code-block:: console
 
-      (d1090exp) $ docker push clawsicus/dump1090exporter:<verison>
+      (d1090exp) $ docker push clawsicus/dump1090exporter:<version>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 aiohttp
-aioprometheus[aiohttp]
+aioprometheus[aiohttp]==21.8.0

--- a/setup.py
+++ b/setup.py
@@ -9,21 +9,21 @@ regexp = re.compile(r".*__version__ = [\'\"](.*?)[\'\"]", re.S)
 init_file = os.path.join(
     os.path.dirname(__file__), "src", "dump1090exporter", "__init__.py"
 )
-with open(init_file, "r") as f:
+with open(init_file, "r") as f:  # pylint: disable=unspecified-encoding
     module_content = f.read()
     match = regexp.match(module_content)
     if match:
         version = match.group(1)
     else:
-        raise RuntimeError("Cannot find __version__ in {}".format(init_file))
+        raise RuntimeError(f"Cannot find __version__ in {init_file}")
 
-with open("README.rst", "r") as f:
+with open("README.rst", "r") as f:  # pylint: disable=unspecified-encoding
     readme = f.read()
 
 
 def parse_requirements(filename):
     """Load requirements from a pip requirements file"""
-    with open(filename, "r") as fd:
+    with open(filename, "r") as fd:  # pylint: disable=unspecified-encoding
         lines = []
         for line in fd:
             line = line.strip()

--- a/src/dump1090exporter/__init__.py
+++ b/src/dump1090exporter/__init__.py
@@ -1,3 +1,3 @@
 from .exporter import Dump1090Exporter
 
-__version__ = "21.0.0"
+__version__ = "21.9.0"


### PR DESCRIPTION
This change provides a quick fix for the issue raised in #34 which is caused by the backwards incompatible API change in aioprometheus AND this package not pinning the dependencies to a known working version. The quick fix is to pin the requirement to the known working version of aioprometheus. 

This resolve #34 

A separate change will update this package to use the latest aioprometheus version.
