### PR TITLE
Disable json mimetype header validation

### DIFF
--- a/src/dump1090exporter/exporter.py
+++ b/src/dump1090exporter/exporter.py
@@ -340,7 +340,7 @@ class Dump1090Exporter:
                     ) as resp:
                         if not resp.status == 200:
                             raise Exception(f"Fetch failed {resp.status}: {resource}")
-                        data = await resp.json()
+                        data = await resp.json(content_type=None)
             except asyncio.TimeoutError:
                 raise Exception(f"Request timed out to {resource}") from None
             except aiohttp.ClientError as exc:


### PR DESCRIPTION
**Warning: untested!**

As some webservers / reverse proxies seem to deliver the wrong `Content-Type` for the `aircraft.json` we should disable the verification of this. 

The `aiohttp` documentation about this can be seen here: https://docs.aiohttp.org/en/stable/client_advanced.html#disabling-content-type-validation-for-json-responses

Related issues e.g. 

https://github.com/claws/dump1090-exporter/issues/22

https://github.com/Thom-x/docker-fr24feed-piaware-dump1090/issues/120
